### PR TITLE
Support swedish characters in answers

### DIFF
--- a/src/main/java/no/saiboten/drumcalendar/answer/AnswerQuestionController.java
+++ b/src/main/java/no/saiboten/drumcalendar/answer/AnswerQuestionController.java
@@ -61,7 +61,7 @@ public class AnswerQuestionController {
 
 		song = song.trim();
 
-		Pattern pattern = Pattern.compile("(\\w|\\s|[0-9]|\\?|\\&|ø|æ|å)+");
+		Pattern pattern = Pattern.compile("(\\w|\\s|[0-9]|\\?|\\&|ø|æ|å|ä|ö)+");
 		Matcher matchSong = pattern.matcher(song);
 		if (!matchSong.matches()) {
 			answerMap


### PR DESCRIPTION
I have added ä and ö as allowed characters in the regex matcher for the answer to properly support having Swedish songs as answers.